### PR TITLE
Refactor assistance flow with typed utilities

### DIFF
--- a/src/components/assistance.tsx
+++ b/src/components/assistance.tsx
@@ -19,18 +19,23 @@ import {
   Flex,
 } from "@chakra-ui/react";
 import { CheckIcon, CloseIcon, EditIcon } from "@chakra-ui/icons";
+import { AssistanceExercise } from "../types";
+
+import { Dispatch, SetStateAction } from "react";
+
+interface SplitTableProps {
+  assistance: AssistanceExercise[];
+  setAssistance: Dispatch<SetStateAction<AssistanceExercise[]>>;
+  split: string;
+  rows: string[];
+}
 
 const SplitTable = ({
   assistance,
   setAssistance,
   split,
   rows,
-}: {
-  assistance: any[];
-  setAssistance: any;
-  split: string;
-  rows: string[];
-}) => {
+}: SplitTableProps) => {
   const getFilteredExos = (split: string, muscle: string) => {
     return assistance.filter(
       (exo) => exo.split === split && exo.group[0] === muscle
@@ -110,7 +115,12 @@ const SplitTable = ({
   );
 };
 
-function Assistance({ assistance, setAssistance }) {
+interface Props {
+  assistance: AssistanceExercise[];
+  setAssistance: Dispatch<SetStateAction<AssistanceExercise[]>>;
+}
+
+function Assistance({ assistance, setAssistance }: Props) {
   return (
     <Box p={10} pt={5} pb={12}>
       <Text px={5} py={2} mb={5} borderRadius={5} bgColor={"gray.100"}>

--- a/src/components/one-rep-max.tsx
+++ b/src/components/one-rep-max.tsx
@@ -10,9 +10,16 @@ import {
 } from "@chakra-ui/react";
 import exercises from "../exercises.json";
 import ORMCalculator from "./orm-calculator";
+import { Dispatch, SetStateAction } from "react";
+import { Lift, Maxes } from "../types";
 
-function OneRepMax({ maxes, setMaxes }) {
-  const lifts = exercises.filter((exo) => exo.category === "lift");
+interface Props {
+  maxes: Maxes;
+  setMaxes: Dispatch<SetStateAction<Maxes>>;
+}
+
+function OneRepMax({ maxes, setMaxes }: Props) {
+  const lifts: Lift[] = exercises.filter((exo) => exo.category === "lift") as Lift[];
 
   const handleChange = (value: string, lift: string) => {
     const updatedMaxes = {

--- a/src/components/program.tsx
+++ b/src/components/program.tsx
@@ -25,7 +25,14 @@ import {
   SQUAT,
   VALID_MUSCLE_GROUPS,
 } from "../constants";
-import { useEffect, useState } from "react";
+import { useEffect, useState, Dispatch, SetStateAction } from "react";
+import {
+  balancedSchedule,
+  weightedRandomSchedule,
+  getWeightedCount,
+  projectOrms,
+} from "../lib/program";
+import { AssistanceExercise, Lift, Maxes } from "../types";
 
 const cyclesMap = {
   3: 9,
@@ -62,14 +69,22 @@ function Program({
   maxes,
   assistance,
   setProgram,
+}: {
+  cycles: number;
+  setCycles: Dispatch<SetStateAction<number>>;
+  assistanceType: string;
+  setAssistanceType: Dispatch<SetStateAction<string>>;
+  maxes: Maxes;
+  assistance: AssistanceExercise[];
+  setProgram: Dispatch<SetStateAction<any>>;
 }) {
-  const lifts = exercises.filter((exo) => exo.category === "lift");
-  const [projectedOrms, setProjectedOrms] = useState({
-    [BENCH]: [maxes[BENCH]],
-    [SQUAT]: [maxes[SQUAT]],
-    [DEADLIFT]: [maxes[DEADLIFT]],
-    [OHP]: [maxes[OHP]],
-    [ROW]: [maxes[ROW]],
+  const lifts: Lift[] = exercises.filter((exo) => exo.category === "lift") as Lift[];
+  const [projectedOrms, setProjectedOrms] = useState<Record<string, number[]>>({
+    [BENCH]: [maxes[BENCH] || 0],
+    [SQUAT]: [maxes[SQUAT] || 0],
+    [DEADLIFT]: [maxes[DEADLIFT] || 0],
+    [OHP]: [maxes[OHP] || 0],
+    [ROW]: [maxes[ROW] || 0],
   });
 
   const [adjustedOrms, setAdjustedOrms] = useState({
@@ -80,96 +95,22 @@ function Program({
     [ROW]: 1,
   });
 
-  const pushExercises = assistance.filter((e) => e.split === "push");
-  const pullExercises = assistance.filter((e) => e.split === "pull");
-  const legExercises = assistance.filter((e) => e.split === "legs");
-
-  // random
-  const [randomizedExos, setRandomizedExos] = useState([]);
+  // assistance scheduling
+  const [randomizedExos, setRandomizedExos] = useState<AssistanceExercise[]>([]);
+  const [balancedExos, setBalancedExos] = useState<AssistanceExercise[]>([]);
   const [toggle, setToggle] = useState(false);
-  const getRandomExos = (array) => {
-    const shuffled = [...array].sort(() => Math.random() - 0.5);
-    return shuffled.slice(0, 3);
-  };
-  useEffect(() => {
-    const totalWeeks = Math.ceil(cycles * 1.5);
-    const result = [];
-    for (let i = 0; i < totalWeeks; i++) {
-      let weeklyExercises = [
-        ...getRandomExos(pushExercises),
-        ...getRandomExos(pullExercises),
-        ...getRandomExos(legExercises),
-        ...getRandomExos(pushExercises),
-        ...getRandomExos(pullExercises),
-      ];
-      result.push(...weeklyExercises);
-    }
-    setRandomizedExos(result);
-  }, [toggle, assistanceType, cycles]);
-
-  const getWeightedCount = (muscle) => {
-    const SECONDARY_INC = 0.25;
-    const count = randomizedExos.reduce((count, exo) => {
-      exo.group.forEach((group, index) => {
-        if (group === muscle) {
-          count += index === 0 ? 1 : SECONDARY_INC;
-        }
-      });
-      return count;
-    }, 0);
-    return Math.ceil(count);
-  };
-
-  // balanced
-  const [balancedExos, setBalancedExos] = useState([]);
-  const getBalancedExos = (array) => {
-    const shuffled = array.sort(() => 0.5 - Math.random());
-    const selected = [];
-    const groups = new Set();
-    for (let exo of shuffled) {
-      const mainGroup = exo.group[0];
-      if (!groups.has(mainGroup)) {
-        selected.push(exo);
-        groups.add(mainGroup);
-      }
-      if (selected.length === 3) break;
-    }
-    return selected;
-  };
 
   useEffect(() => {
-    const totalWeeks = Math.ceil(cycles * 1.5);
-    const result = [];
-    for (let i = 0; i < totalWeeks; i++) {
-      let weeklyExercises = [
-        ...getBalancedExos(pushExercises),
-        ...getBalancedExos(pullExercises),
-        ...getBalancedExos(legExercises),
-        ...getBalancedExos(pushExercises),
-        ...getBalancedExos(pullExercises),
-      ];
-      result.push(...weeklyExercises);
-    }
-    setBalancedExos(result);
-  }, [assistanceType, cycles]);
+    setRandomizedExos(weightedRandomSchedule(assistance, cycles));
+  }, [toggle, assistance, cycles]);
+
+  useEffect(() => {
+    setBalancedExos(balancedSchedule(assistance, cycles));
+  }, [assistance, cycles]);
 
   // 1RM projection
   useEffect(() => {
-    const updatedOrms = { ...projectedOrms };
-    lifts.forEach((lift) => {
-      const initialORM = updatedOrms[lift.name][0] || 0;
-      const newArray = [initialORM * adjustedOrms[lift.name]];
-      for (let i = 1; i <= cycles; i++) {
-        const prevORM = newArray[newArray.length - 1];
-        if (i % 5 === 0) {
-          newArray.push(prevORM - lift.deload);
-        } else {
-          newArray.push(prevORM + lift.overload);
-        }
-      }
-      updatedOrms[lift.name] = newArray;
-    });
-    setProjectedOrms(updatedOrms);
+    setProjectedOrms(projectOrms(lifts, maxes, cycles, adjustedOrms));
   }, [cycles, maxes, adjustedOrms]);
 
   // program
@@ -306,7 +247,7 @@ function Program({
                   title: muscle,
                   value:
                     assistanceType === "random"
-                      ? getWeightedCount(muscle)
+                      ? getWeightedCount(randomizedExos, muscle)
                       : balancedExos.filter((exo) => exo.group[0] === muscle)
                           .length,
                   color: groupColors[muscle],

--- a/src/lib/program.ts
+++ b/src/lib/program.ts
@@ -1,0 +1,100 @@
+import { AssistanceExercise, Lift, Maxes } from '../types';
+
+export const projectOrms = (
+  lifts: Lift[],
+  maxes: Maxes,
+  cycles: number,
+  adjustments: Record<string, number>
+): Record<string, number[]> => {
+  const result: Record<string, number[]> = {};
+  lifts.forEach((lift) => {
+    const initial = maxes[lift.name] || 0;
+    const arr = [initial * (adjustments[lift.name] || 1)];
+    for (let i = 1; i <= cycles; i++) {
+      const prev = arr[arr.length - 1];
+      if (i % 5 === 0) {
+        arr.push(prev - lift.deload);
+      } else {
+        arr.push(prev + lift.overload);
+      }
+    }
+    result[lift.name] = arr;
+  });
+  return result;
+};
+
+export const weightedRandomSchedule = (
+  assistance: AssistanceExercise[],
+  cycles: number
+): AssistanceExercise[] => {
+  const push = assistance.filter((e) => e.split === 'push');
+  const pull = assistance.filter((e) => e.split === 'pull');
+  const legs = assistance.filter((e) => e.split === 'legs');
+  const totalWeeks = Math.ceil(cycles * 1.5);
+  const schedule: AssistanceExercise[] = [];
+  const random = (array: AssistanceExercise[]) =>
+    [...array].sort(() => Math.random() - 0.5).slice(0, 3);
+  for (let i = 0; i < totalWeeks; i++) {
+    schedule.push(
+      ...random(push),
+      ...random(pull),
+      ...random(legs),
+      ...random(push),
+      ...random(pull)
+    );
+  }
+  return schedule;
+};
+
+export const balancedSchedule = (
+  assistance: AssistanceExercise[],
+  cycles: number
+): AssistanceExercise[] => {
+  const push = assistance.filter((e) => e.split === 'push');
+  const pull = assistance.filter((e) => e.split === 'pull');
+  const legs = assistance.filter((e) => e.split === 'legs');
+  const totalWeeks = Math.ceil(cycles * 1.5);
+  const schedule: AssistanceExercise[] = [];
+
+  const select = (array: AssistanceExercise[]) => {
+    const shuffled = [...array].sort(() => Math.random() - 0.5);
+    const selected: AssistanceExercise[] = [];
+    const groups = new Set<string>();
+    for (const exo of shuffled) {
+      const mainGroup = exo.group[0];
+      if (!groups.has(mainGroup)) {
+        selected.push(exo);
+        groups.add(mainGroup);
+      }
+      if (selected.length === 3) break;
+    }
+    return selected;
+  };
+
+  for (let i = 0; i < totalWeeks; i++) {
+    schedule.push(
+      ...select(push),
+      ...select(pull),
+      ...select(legs),
+      ...select(push),
+      ...select(pull)
+    );
+  }
+  return schedule;
+};
+
+export const getWeightedCount = (
+  exos: AssistanceExercise[],
+  muscle: string
+): number => {
+  const SECONDARY_INC = 0.25;
+  const count = exos.reduce((acc, exo) => {
+    exo.group.forEach((group, index) => {
+      if (group === muscle) {
+        acc += index === 0 ? 1 : SECONDARY_INC;
+      }
+    });
+    return acc;
+  }, 0);
+  return Math.ceil(count);
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,15 @@
+export interface Exercise {
+  name: string;
+  group: string[];
+  category: string;
+  split: string;
+}
+
+export interface Lift extends Exercise {
+  overload: number;
+  deload: number;
+}
+
+export interface AssistanceExercise extends Exercise {}
+
+export type Maxes = Record<string, number | undefined>;


### PR DESCRIPTION
## Summary
- add typed program utilities and exercise types
- refactor Program component to use helpers
- use typed props in Assistance and OneRepMax components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68479793dab8832692055fa1d0585705